### PR TITLE
Fix broken build 

### DIFF
--- a/pump/tandem/src/main/kotlin/app/aaps/pump/tandem/di/TandemModuleImpl.kt
+++ b/pump/tandem/src/main/kotlin/app/aaps/pump/tandem/di/TandemModuleImpl.kt
@@ -1,10 +1,12 @@
 package app.aaps.pump.tandem.di
 
 import app.aaps.core.interfaces.logging.AAPSLogger
+import app.aaps.pump.tandem.common.comm.ui.TandemUIDataStore
 import app.aaps.pump.tandem.common.concurrency.CommSuspendGate
 import app.aaps.pump.tandem.common.concurrency.PumpAvailabilityState
 import app.aaps.pump.tandem.common.concurrency.PumpOpQueue
 import app.aaps.pump.tandem.common.database.dao.TandemQualifyingEventsDao
+import app.aaps.pump.tandem.common.driver.tandemUiDataStore
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -33,4 +35,11 @@ open class TandemModuleImpl {
         availability: PumpAvailabilityState,
         commSuspend: CommSuspendGate
     ): PumpOpQueue = PumpOpQueue(logger, availability, commSuspend)
+
+    // Returns the single global instance (the same one backing the tandemDataStore write-only
+    // handle and the LocalTandemDataStore composition local), so Dagger-injected consumers
+    // (e.g. TandemUICommunication) share it rather than getting a second instance.
+    @Provides
+    @Singleton
+    fun provideTandemUIDataStore(): TandemUIDataStore = tandemUiDataStore
 }


### PR DESCRIPTION
The interface-segregation commit deleted provideTandemUIDataStore(), but the Hilt graph still needs the binding (TandemUICommunication has an @Inject constructor taking TandemUIDataStore). assembleFullDebug failed with Dagger/MissingBinding; module compile and unit tests didn't catch it.

Restore the provider, but return the single global tandemUiDataStore instance instead of constructing a new one. Dagger-injected consumers now share the same instance as the tandemDataStore write-only handle and the LocalTandemDataStore composition local — making the single-instance property actually hold (the old provider had created a separate second instance).