### PR TITLE
Tandem: set preventQueueExecution when entering Actions/Data

### DIFF
--- a/pump/tandem/src/main/kotlin/app/aaps/pump/tandem/mobi/ui/TandemUiController.kt
+++ b/pump/tandem/src/main/kotlin/app/aaps/pump/tandem/mobi/ui/TandemUiController.kt
@@ -186,10 +186,12 @@ class TandemUiController @Inject constructor(
             }
             RefreshData.START_ACTIONS       -> {
                 tandemPumpUtil.preventConnect = true
+                tandemPumpStatus.preventQueueExecution = true
                 ds.reminderDateTime.value = tandemPumpStatus.tandemSiteReminder
             }
             RefreshData.START_DATA       -> {
                 tandemPumpUtil.preventConnect = true
+                tandemPumpStatus.preventQueueExecution = true
             }
         }
     }


### PR DESCRIPTION
preventQueueExecution was added to TandemPumpStatus and checked in isBusy(), but nothing ever set it to true. Only the exit paths (disposeTandemUiCommunication, the Compose dispose effect) reset it to false. This mirrors the existing preventConnect flag so the queue is actually blocked while a user is in the Actions or Data screens.