### PR TITLE
Tandem: fix setPumpSounds to actually change quick bolus/reminder/alert/alarm sounds

### DIFF
--- a/pump/tandem/src/main/kotlin/app/aaps/pump/tandem/common/driver/connector/TandemPumpConnector.kt
+++ b/pump/tandem/src/main/kotlin/app/aaps/pump/tandem/common/driver/connector/TandemPumpConnector.kt
@@ -1323,18 +1323,29 @@ class TandemPumpConnector @Inject constructor(var tandemPumpStatus: TandemPumpSt
 
     private fun setPumpSounds(soundVolume: PumpGlobalsResponse.AnnunciationEnum): DataCommandResponse<AdditionalResponseDataInterface?> {
 
-        //aapsLogger.info(LTag.PUMPCOMM, "set All Pump Sounds to ${soundVolume.name}")
+        aapsLogger.info(LTag.PUMPCOMM, "set All Pump Sounds to ${soundVolume.name}")
 
-        // TODO setPumpSounds
-        aapsLogger.error(LTag.PUMPCOMM, "set GeneralAnnun to ${soundVolume.name} NOT IMPLEMENTED")
+        // The GENERAL bit here writes what PumpGlobalsResponse reads back as buttonAnnun - the
+        // read and write messages use different names for the same pump setting.
+        // isSoundIncorrectlySet() also checks fillTubingAnnun, but SetPumpSoundsRequest has no
+        // field for it, so that one can never be corrected by this request.
+        val changeBitmask = SetPumpSoundsRequest.ChangeBitmask.toBitmask(
+            SetPumpSoundsRequest.ChangeBitmask.QUICK_BOLUS,
+            SetPumpSoundsRequest.ChangeBitmask.GENERAL,
+            SetPumpSoundsRequest.ChangeBitmask.REMINDER,
+            SetPumpSoundsRequest.ChangeBitmask.ALERT,
+            SetPumpSoundsRequest.ChangeBitmask.ALARM
+        )
 
-        val pumpSoundRequest = SetPumpSoundsRequest(soundVolume, // quicbolus
-                                                    soundVolume, //general
-                                                    soundVolume,  // reminder
-                                                    soundVolume,  // alert
-                                                    soundVolume, // alarm
-                                                    null, // cgmAlert
-                                                    SetPumpSoundsRequest.ChangeBitmask.GENERAL)
+        val pumpSoundRequest = SetPumpSoundsRequest(0, // firstByteUnknown
+                                                    soundVolume.id(), // quickBolus
+                                                    soundVolume.id(), // general (== PumpGlobalsResponse.buttonAnnun)
+                                                    soundVolume.id(), // reminder
+                                                    soundVolume.id(), // alert
+                                                    soundVolume.id(), // alarm
+                                                    0, // cgmAlertAnnunA (not changed, bit not set)
+                                                    0, // cgmAlertAnnunB (not changed, bit not set)
+                                                    changeBitmask)
 
         val responseMessage: SetPumpSoundsResponse? = getCommunicationManager()
             ?.sendCommand(pumpSoundRequest) as SetPumpSoundsResponse?
@@ -1352,13 +1363,6 @@ class TandemPumpConnector @Inject constructor(var tandemPumpStatus: TandemPumpSt
                 null
             )
         }
-
-            return DataCommandResponse(
-                PumpCommandType.CustomCommand, false,
-                "Error getting response from sending SetPumpSoundsRequest: NOT YET IMPLEMENTED",
-                null
-            )
-
     }
 
     private fun dismissNotificationAlert(value: Long): DataCommandResponse<AdditionalResponseDataInterface?> {

--- a/pump/tandem/src/main/kotlin/app/aaps/pump/tandem/common/driver/connector/TandemPumpConnector.kt
+++ b/pump/tandem/src/main/kotlin/app/aaps/pump/tandem/common/driver/connector/TandemPumpConnector.kt
@@ -1327,8 +1327,10 @@ class TandemPumpConnector @Inject constructor(var tandemPumpStatus: TandemPumpSt
 
         // The GENERAL bit here writes what PumpGlobalsResponse reads back as buttonAnnun - the
         // read and write messages use different names for the same pump setting.
-        // isSoundIncorrectlySet() also checks fillTubingAnnun, but SetPumpSoundsRequest has no
-        // field for it, so that one can never be corrected by this request.
+        // isSoundIncorrectlySet() also checks bolusAnnun and fillTubingAnnun. Neither has a
+        // matching field anywhere in pumpX2 (checked every request class with an Annun field,
+        // and the fill-tubing mode requests take no parameters at all), so this request can
+        // never correct either one - there is currently no known way to write them.
         val changeBitmask = SetPumpSoundsRequest.ChangeBitmask.toBitmask(
             SetPumpSoundsRequest.ChangeBitmask.QUICK_BOLUS,
             SetPumpSoundsRequest.ChangeBitmask.GENERAL,


### PR DESCRIPTION

setPumpSounds() built a SetPumpSoundsRequest with all five annunciation fields filled in, but only flagged the GENERAL bit as changed. Tandem pumps only apply fields whose change bit is set, so quick bolus, reminder, alert, and alarm sounds were silently not written, even though isSoundIncorrectlySet() checks all of them.

Also removes an unreachable "NOT YET IMPLEMENTED" return that could never run (it followed two other return statements), and adds a comment noting that PumpGlobalsResponse.buttonAnnun (read) and SetPumpSoundsRequest.generalAnnun (write) are the same pump setting under different names
